### PR TITLE
Feature/zsh nvm removed

### DIFF
--- a/.config/zsh/.zshrc
+++ b/.config/zsh/.zshrc
@@ -188,6 +188,8 @@ NEWLINE=$'\n'
 #Custom scripts
 source ~/.config/zsh/custom/dashboard.zfunc
 
-#export NVM_DIR="$HOME/.config/nvm"
-#[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
-#[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+
+eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"

--- a/.config/zsh/.zshrc
+++ b/.config/zsh/.zshrc
@@ -70,7 +70,7 @@ ZSH_THEME="duellj"
 # Custom plugins may be added to $ZSH_CUSTOM/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
-plugins=(git aliases brew bun colored-man-pages colorize composer dnf docker docker-compose fzf git-commit history jsontools kitty laravel laravel5 node npm nvm zsh-nvm perl pipenv python pylint pyenv rsync safe-paste sublime symfony symfony6 systemadmin thefuck themes timer ufw web-search wp-cli zsh-autosuggestions zsh-syntax-highlighting zsh-bat)
+plugins=(git aliases brew bun colored-man-pages colorize composer dnf docker docker-compose fzf git-commit history jsontools kitty laravel laravel5 node npm nvm perl pipenv python pylint pyenv rsync safe-paste sublime symfony symfony6 systemadmin thefuck themes timer ufw web-search wp-cli zsh-autosuggestions zsh-syntax-highlighting zsh-bat)
 
 source $ZSH/oh-my-zsh.sh
 
@@ -187,3 +187,7 @@ NEWLINE=$'\n'
 
 #Custom scripts
 source ~/.config/zsh/custom/dashboard.zfunc
+
+#export NVM_DIR="$HOME/.config/nvm"
+#[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+#[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion

--- a/.zprofile
+++ b/.zprofile
@@ -61,3 +61,6 @@ export MANPAGER="less -R --use-color -Dd+r -Du+b" # colored man pages
 #export LESS_TERMCAP_se="$(printf '%b' '[0m')"
 #export LESS_TERMCAP_us="$(printf '%b' '[1;32m')"
 #export LESS_TERMCAP_ue="$(printf '%b' '[0m')"
+
+export NVM_DIR=~/.nvm
+ [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"


### PR DESCRIPTION
I tried reinstalling nvm manually and with brew but I couldn't get the zsh-nvm to be detected by oh-my-zsh plugin. Nvm is still available but no shortcut for zsh I guess.