### PR TITLE
Fix connection timeout error from node-exporter

### DIFF
--- a/server/prometheus/docker-compose.yml
+++ b/server/prometheus/docker-compose.yml
@@ -1,8 +1,16 @@
-version: '3.8'
-
 volumes:
-  prometheus-data: {}
-  grafana-data: {}
+  prometheus-data:
+    driver: local
+    driver_opts:
+      o: bind
+      type: none
+      device: /home/zero/server/prometheus/prometheus-data
+  grafana-data:
+    driver: local
+    driver_opts:
+      o: bind
+      type: none
+      device: /home/zero/server/prometheus/grafana-data
 
 services:
   node_exporter:
@@ -10,17 +18,22 @@ services:
     container_name: node_exporter
     command:
       - '--path.rootfs=/host'
-    network_mode: host
+    ports:
+      - 9100:9100
     pid: host
     restart: unless-stopped
     volumes:
       - '/:/host:ro,rslave'
+    networks:
+      - host-monitor
 
   prometheus:
     image: prom/prometheus:latest
     container_name: prometheus
     ports:
       - '9090:9090'
+    expose:
+      - 9090
     restart: unless-stopped
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
@@ -28,6 +41,10 @@ services:
     command:
       - '--web.enable-lifecycle'
       - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--web.console.libraries=/etc/prometheus/console_libraries'
+      - '--web.console.templates=/etc/prometheus/consoles'
+    networks:
+      - host-monitor
 
   grafana:
     image: grafana/grafana:latest
@@ -37,4 +54,10 @@ services:
     restart: unless-stopped
     volumes:
       - grafana-data:/var/lib/grafana
+    networks:
+      - host-monitor
+
+networks:
+  host-monitor:
+    driver: bridge
 

--- a/server/prometheus/prometheus.yml
+++ b/server/prometheus/prometheus.yml
@@ -6,5 +6,9 @@ scrape_configs:
     static_configs:
       - targets: ['localhost:9090']
   - job_name: 'node'
+    scrape_interval: 2m
+    scrape_timeout: 1m
     static_configs:
-      - targets: ['192.168.0.44:9100']
+      - targets: ['172.27.0.2:9100']
+    tls_config:
+      insecure_skip_verify: true


### PR DESCRIPTION
When adding a new service to the prometheus group, I couldn't connect to node-exporter. 
Define port for node-exporter service
Define volumes -data for prometheus and graphana to keep data with docker compose file
Define default network for everything prometheus related to communicate on