### PR TITLE
Adds Loki container to prometheus network

### DIFF
--- a/server/loki/config/loki-config.yml
+++ b/server/loki/config/loki-config.yml
@@ -1,0 +1,42 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3101
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+# By default, Loki will send anonymous, but uniquely-identifiable usage and configuration
+# analytics to Grafana Labs. These statistics are sent to https://stats.grafana.org/
+#
+# Statistics help us better understand how Loki is used, and they show us performance
+# levels for most users. This helps us prioritize features and documentation.
+# For more information on what's sent, look at
+# https://github.com/grafana/loki/blob/main/pkg/analytics/stats.go
+# Refer to the buildReport method to see what goes into a report.
+#
+# If you would like to disable reporting, uncomment the following lines:
+analytics:
+  reporting_enabled: false

--- a/server/loki/docker-compose.yml
+++ b/server/loki/docker-compose.yml
@@ -1,0 +1,25 @@
+volumes:
+  loki-data:
+    driver: local
+    driver_opts:
+      o: bind
+      type: none
+      device: /home/zero/server/loki/loki-data
+
+networks:
+  prometheus_host-monitor:
+    external: true
+
+services:
+  loki:
+    image: grafana/loki:latest
+    container_name: loki
+    ports:
+      - "3101:3100"
+    volumes:
+      - ./config/loki-config.yml:/etc/loki/config.yaml:ro
+      - loki-data:/loki:rw
+    command: -config.file=/etc/loki/config.yaml
+    restart: unless-stopped
+    networks:
+      - prometheus_host-monitor


### PR DESCRIPTION
Basic setup to connect to existing network "prometheus_host-monitor" in Docker.